### PR TITLE
Performance Enhancements

### DIFF
--- a/llm_katan/cli.py
+++ b/llm_katan/cli.py
@@ -153,6 +153,12 @@ logger = logging.getLogger(__name__)
     default="",
     help="Comma-separated providers that skip auto tool_use responses (e.g., 'anthropic').",
 )
+@click.option(
+    "--disable-dashboard",
+    is_flag=True,
+    default=False,
+    help="Disable HTML dashboard, may be useful to increase performance"
+)
 @click.version_option(version=__version__, prog_name="llm-katan")
 def main(
     model: str,
@@ -182,6 +188,7 @@ def main(
     ttft_ms: int,
     itl_ms: int,
     no_auto_tool_providers: str,
+    disable_dashboard: bool,
 ):
     """LLM Katan - One tiny model, every LLM API.
 
@@ -249,6 +256,7 @@ def main(
         ttft_ms=ttft_ms,
         itl_ms=itl_ms,
         no_auto_tool_providers=[p.strip() for p in no_auto_tool_providers.split(",") if p.strip()],
+        dashboard_enabled=not disable_dashboard
     )
 
     protocol = "https" if config.tls else "http"

--- a/llm_katan/config.py
+++ b/llm_katan/config.py
@@ -48,6 +48,7 @@ class ServerConfig:
     ttft_ms: int = 0
     itl_ms: int = 0
     no_auto_tool_providers: list[str] = field(default_factory=list)
+    dashboard_enabled: bool = True
 
     def __post_init__(self):
         # Environment variable overrides (before served_model_name defaulting)

--- a/llm_katan/server.py
+++ b/llm_katan/server.py
@@ -236,7 +236,8 @@ def create_app(config: ServerConfig) -> FastAPI:
         lifespan=lifespan,
     )
     app.state.config = config
-    app.add_middleware(DashboardMiddleware)
+    if config.dashboard_enabled:
+        app.add_middleware(DashboardMiddleware)
 
     @app.get("/health")
     async def health():

--- a/llm_katan/server.py
+++ b/llm_katan/server.py
@@ -140,6 +140,9 @@ class DashboardMiddleware(BaseHTTPMiddleware):
         start = time.time()
         response = await call_next(request)
         elapsed = time.time() - start
+        # Skip streaming requests, otherwise large TTFT latencies occur
+        if response.headers.get("content-type", "").startswith("text/event-stream"):
+            return response
 
         # Capture response body
         resp_body = None

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,85 @@
+"""Tests for DashboardMiddleware — verifies streaming requests bypass capture."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from llm_katan.config import ServerConfig
+from llm_katan.model import ModelBackend
+from llm_katan.providers.anthropic import AnthropicProvider
+from llm_katan.server import ServerMetrics, create_app
+from llm_katan.stats import PersistentStats
+
+
+class MockBackend(ModelBackend):
+    async def load_model(self):
+        pass
+
+    async def _generate_text(self, prompt, max_tokens, temperature):
+        generated = "dashboard test response"
+        return generated, 10, len(generated)
+
+
+def make_app():
+    config = ServerConfig(
+        model_name="test-model",
+        served_model_name="claude-test",
+        port=8000,
+        providers=["anthropic"],
+    )
+    app = create_app(config)
+    backend = MockBackend(config)
+    app.state.backend = backend
+    app.state.metrics = ServerMetrics()
+    app.state.stats = PersistentStats()
+    provider = AnthropicProvider(backend=backend)
+    provider.register_routes(app)
+    return app
+
+
+def base_request(**overrides):
+    req = {
+        "model": "claude-test",
+        "max_tokens": 100,
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    req.update(overrides)
+    return req
+
+
+HEADERS = {
+    "Content-Type": "application/json",
+    "anthropic-version": "2023-06-01",
+    "x-api-key": "sk-ant-test-key",
+}
+
+
+@pytest_asyncio.fixture
+async def client():
+    app = make_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+class TestDashboardStreamBypass:
+    """Streaming requests should bypass DashboardMiddleware (no broadcast)."""
+
+    async def test_non_streaming_triggers_broadcast(self, client):
+        """Positive control: non-streaming request DOES broadcast an event."""
+        with patch("llm_katan.server.broadcaster.broadcast", new_callable=AsyncMock) as mock_broadcast:
+            resp = await client.post("/v1/messages", json=base_request(), headers=HEADERS)
+            assert resp.status_code == 200
+            mock_broadcast.assert_called_once()
+
+    async def test_streaming_skips_broadcast(self, client):
+        """Streaming request should NOT broadcast — the middleware returns early."""
+        with patch("llm_katan.server.broadcaster.broadcast", new_callable=AsyncMock) as mock_broadcast:
+            resp = await client.post(
+                "/v1/messages", json=base_request(stream=True), headers=HEADERS
+            )
+            assert resp.status_code == 200
+            mock_broadcast.assert_not_called()


### PR DESCRIPTION
This PR adds 2 distinct capabilities,

Previously --workers did not properly scale across CPU cores.  Now with `run_server_multiprocessing` multiple uvicorn processes can be spun up at the same time, allowing multiple cores to be for responding to requests.

A new option is introduced, `--disable-dashboard`, during stress testing, it was discovered that the dashboard middleware incurred a significant processing delay.  This option disables registering the dashboard and has decreased latency significantly (I've seen time to first token latency drop from 18 seconds to 35 milliseconds by doing this).