### PR TITLE
Add workflow to publish container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+name: Build Release Container
+
 on:
   push:
     branches:
@@ -5,8 +7,6 @@ on:
     tags:
       - "*"
   pull_request:
-
-permissions: write-all
 
 env:
   REGISTRY: quay.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  pull_request:
+
+permissions: write-all
+
+env:
+  REGISTRY: quay.io
+  IMAGE_NAME: yossiovadia/llm-katan
+  RELEASE_TAG: ${{ github.ref_name }}
+
+jobs:
+  containerize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Quay
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build Container
+        uses: docker/build-push-action@v6
+        with:
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Containerfile
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This PR adds a GitHub workflow to publish container images when a git tag is pushed (can be triggered via GitHub releases as well).

There are also non-pushing builds that occur on PRs and on pushes to main.  This is to ensure that the Containerfile never becomes stale.

## Required before merge
- [ ] quay.io/yossiovadia/llm-katan must be created
- [ ] Credentials for this repo will need to be provided in this repo's secrets, using `QUAY_USERNAME` and `QUAY_PASSWORD`